### PR TITLE
Make consumers aware that they should specify version

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ it, simply add the following line to your Podfile:
 ```ruby
 pod 'StickyTabBarViewController', '0.0.3'
 ```
-(Latest version is 0.0.3, although there is a tag with higher version number)
+(Latest version is 0.0.3, although there is a tag with higher version number (1.0.2))
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ StickyTabBarViewController is available through [CocoaPods](http://cocoapods.org
 it, simply add the following line to your Podfile:
 
 ```ruby
-pod 'StickyTabBarViewController'
+pod 'StickyTabBarViewController', '0.0.3'
 ```
+(Latest version is 0.0.3, although there is a tag with higher version number)
 
 ## Usage
 


### PR DESCRIPTION
This PR updates README and adds version `0.0.3` to installation guide. It also adds extra information explaining that `0.0.3` is the latest version although there is a version with a higher number is available.

Even though `0.0.3` is the latest published version through Cocoapods, running `pod install` on a fresh project with only `pod 'StickyTabBarViewController'` in `Podfile`, results in the installation of `1.0.2` :/