### PR TITLE
Make expandable VC available from tab bar

### DIFF
--- a/StickyTabBarViewController/Classes/ExpandableViewController.swift
+++ b/StickyTabBarViewController/Classes/ExpandableViewController.swift
@@ -14,7 +14,7 @@ public protocol Expandable: UIViewController {
 }
 
 public extension Expandable {
-    var container: StickyViewControllerSupporting? {
+    weak var container: StickyViewControllerSupporting? {
         get { tabBarController as? StickyViewControllerSupporting }
         
         set { /* No steps needed */ }

--- a/StickyTabBarViewController/Classes/StickyViewControllerSupportingTabBarController.swift
+++ b/StickyTabBarViewController/Classes/StickyViewControllerSupportingTabBarController.swift
@@ -80,15 +80,11 @@ open class StickyViewControllerSupportingTabBarController: UITabBarController, S
                             self.view.layoutIfNeeded()
             }) { (completed) in
                 if completed {
-                    collapsableVCFlow.view.removeFromSuperview()
-                    collapsableVCFlow.removeFromParent()
-                    self.collapsableVCFlow = nil
+                    self.removeStickyViewController()
                 }
             }
         } else {
-            collapsableVCFlow.view.removeFromSuperview()
-            collapsableVCFlow.removeFromParent()
-            self.collapsableVCFlow = nil
+            removeStickyViewController()
         }
     }
     
@@ -106,5 +102,17 @@ open class StickyViewControllerSupportingTabBarController: UITabBarController, S
             return
         }
         collapsableVCFlow.expand()
+    }
+    
+    private func removeStickyViewController() {
+        guard let childViewController = childViewController, let collapsableVCFlow = collapsableVCFlow else {
+            return
+        }
+        childViewController.view.removeFromSuperview()
+        childViewController.removeFromParent()
+        collapsableVCFlow.view.removeFromSuperview()
+        collapsableVCFlow.removeFromParent()
+        self.collapsableVCFlow = nil
+        self.childViewController = nil
     }
 }

--- a/StickyTabBarViewController/Classes/StickyViewControllerSupportingTabBarController.swift
+++ b/StickyTabBarViewController/Classes/StickyViewControllerSupportingTabBarController.swift
@@ -104,6 +104,8 @@ open class StickyViewControllerSupportingTabBarController: UITabBarController, S
         collapsableVCFlow.expand()
     }
     
+    // MARK: - Private API
+    
     private func removeStickyViewController() {
         guard let childViewController = childViewController, let collapsableVCFlow = collapsableVCFlow else {
             return

--- a/StickyTabBarViewController/Classes/StickyViewControllerSupportingTabBarController.swift
+++ b/StickyTabBarViewController/Classes/StickyViewControllerSupportingTabBarController.swift
@@ -10,6 +10,7 @@ import UIKit
 public protocol StickyViewControllerSupporting: UITabBarController {
     var collapsedHeight: CGFloat { get set }
     var animationDuration: TimeInterval { get set }
+    var childViewController: Expandable? { get }
     func configureCollapsableChild(_ childViewController: Expandable, isFullScreenOnFirstAppearance: Bool)
     func removeCollapsableChild(animated: Bool)
     func collapseChild()
@@ -21,6 +22,7 @@ open class StickyViewControllerSupportingTabBarController: UITabBarController, S
     // MARK: - Public properties
     public var collapsedHeight: CGFloat = 50.0
     public var animationDuration: TimeInterval = 0.5
+    public var childViewController: Expandable?
     
     // MARK: - Private properties
     private var collapsableVCFlow: ExpandableViewController?
@@ -38,6 +40,7 @@ open class StickyViewControllerSupportingTabBarController: UITabBarController, S
         }
         childViewController.loadView()
         childViewController.container = self
+        self.childViewController = childViewController
         collapsableVCFlow = ExpandableViewController(withChildVC: childViewController,
                                                      collapsedHeight: collapsedHeight,
                                                      animationDuration: animationDuration)

--- a/StickyTabBarViewController/Classes/StickyViewControllerSupportingTabBarController.swift
+++ b/StickyTabBarViewController/Classes/StickyViewControllerSupportingTabBarController.swift
@@ -107,11 +107,9 @@ open class StickyViewControllerSupportingTabBarController: UITabBarController, S
     // MARK: - Private API
     
     private func removeStickyViewController() {
-        guard let childViewController = childViewController, let collapsableVCFlow = collapsableVCFlow else {
+        guard let collapsableVCFlow = collapsableVCFlow else {
             return
         }
-        childViewController.view.removeFromSuperview()
-        childViewController.removeFromParent()
         collapsableVCFlow.view.removeFromSuperview()
         collapsableVCFlow.removeFromParent()
         self.collapsableVCFlow = nil


### PR DESCRIPTION
## Description
This PR makes sure it is possible to access actual sticky view controller from tab bar to modify it, 

Closes #14 

Imagine a view controller named `SampleChildViewController` is already sticked to the tab bar controller. Now consumers will be able to access this view controller any where with tabBarController access as following:

```swift
    var tabController: StickyViewControllerSupportingTabBarController? {
        if let tabBarController = tabBarController as? StickyViewControllerSupportingTabBarController {
            return tabBarController
        }
        return nil
    }

    override func viewDidLoad() {
        super.viewDidLoad()
        
        
        if let stickyViewController = tabController?.childViewController as? SampleChildViewController {
            // update it's content or anything.
            stickyViewController.minimisedView.backgroundColor = .black
        }
    }
```


## Definition of Done

Has changes to public api but not urgent, so no need to publish a version, we can edit readme in the future, when there is a need for a release

- [X] Has changes to Public API (Requires README update)
- [ ] Updated README
