### PR TITLE
Instead of setting constraints to child view controllers view, just confine it within parents bounds

### DIFF
--- a/StickyTabBarViewController.podspec
+++ b/StickyTabBarViewController.podspec
@@ -9,7 +9,7 @@
 Pod::Spec.new do |s|
 
   s.name         = 'StickyTabBarViewController'
-  s.version      = '0.0.4'
+  s.version      = '0.0.5'
   s.summary      = 'A sticky and expandable view controller on top of TabBar'
 
   s.description  = <<-DESC

--- a/StickyTabBarViewController/Classes/ExpandableViewController.swift
+++ b/StickyTabBarViewController/Classes/ExpandableViewController.swift
@@ -88,10 +88,7 @@ class ExpandableViewController: UIViewController {
     private func configureChildVC() {
         addChild(childVC)
         view.addSubview(childVC.view)
-        childVC.view.topAnchor.constraint(equalTo: view.topAnchor, constant: 0.0).isActive = true
-        childVC.view.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 0.0).isActive = true
-        childVC.view.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: 0.0).isActive = true
-        childVC.view.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: 0.0).isActive = true
+        childVC.view.frame = self.view.bounds
         childVC.didMove(toParent: self)
     }
     

--- a/StickyTabBarViewController/Classes/ExpandableViewController.swift
+++ b/StickyTabBarViewController/Classes/ExpandableViewController.swift
@@ -88,7 +88,7 @@ class ExpandableViewController: UIViewController {
     private func configureChildVC() {
         addChild(childVC)
         view.addSubview(childVC.view)
-        childVC.view.frame = self.view.bounds
+        childVC.view.frame = view.bounds
         childVC.didMove(toParent: self)
     }
     


### PR DESCRIPTION

## Description
While investigating, I found out that there were issues for different iPhone simulators as well, this should fix for all device types now.

Ideally a child view controller will have its own constraints and setting constraints to expandable's view directly was causing problems of conflicting constraints. This fix doesn't care about constraining child view to the parent one but rather makes your it lives within the bounds of it.

How it looks on iPad:
**Collapsed:**
![Simulator Screen Shot - iPad Pro (12 9-inch) (4th generation) - 2020-05-29 at 21 29 12](https://user-images.githubusercontent.com/30630955/83298363-97da9c00-a1f4-11ea-8f37-361783cdbc5d.png)

**Expanded:**
![Simulator Screen Shot - iPad Pro (12 9-inch) (4th generation) - 2020-05-29 at 21 29 14](https://user-images.githubusercontent.com/30630955/83298373-9c9f5000-a1f4-11ea-9d81-589512380f3a.png)


Closes #18 

## Definition of Done

