### PR TITLE
Call loadViewIfNeeded instead of loadView

### DIFF
--- a/StickyTabBarViewController/Classes/StickyViewControllerSupportingTabBarController.swift
+++ b/StickyTabBarViewController/Classes/StickyViewControllerSupportingTabBarController.swift
@@ -38,7 +38,7 @@ open class StickyViewControllerSupportingTabBarController: UITabBarController, S
         guard collapsableVCFlow == nil else {
             return
         }
-        childViewController.loadView()
+        childViewController.loadViewIfNeeded()
         childViewController.container = self
         self.childViewController = childViewController
         collapsableVCFlow = ExpandableViewController(withChildVC: childViewController,


### PR DESCRIPTION
## Description

> You should never call this method directly. 
Reference: https://developer.apple.com/documentation/uikit/uiviewcontroller/1621454-loadview

It sounds like calling loadView is a bad thing, loadViewIfNeeded seems to be more appropriate for this case. I tested and couldn't see any changes. @Thurman1776- 
